### PR TITLE
Various typing fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3908,6 +3908,7 @@ declare namespace Tone {
   interface PingPongDelayOptions {
     delayTime?: Encoding.Time;
     maxDelayTime?: Encoding.NormalRange;
+    feedback?: Encoding.NormalRange;
   }
 
   /**
@@ -3921,6 +3922,9 @@ declare namespace Tone {
    * the same interval after the first
    */
   class PingPongDelay extends StereoXFeedbackEffect {
+    constructor(options?: PingPongDelayOptions)
+    constructor(delayTime?: Encoding.Time, feedback?: Encoding.NormalRange)
+
     /**
      * The delay time signal
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -1116,7 +1116,7 @@ declare namespace Tone {
      * The event will fire at the interval starting at the startTime
      * and for the specified duration.
      */
-    scheduleRepeat(callback: Callback, interval: Encoding.Time, startTime: Encoding.TransportTime, duration: Encoding.Time): number;
+    scheduleRepeat(callback: Callback, interval: Encoding.Time, startTime?: Encoding.TransportTime, duration?: Encoding.Time): number;
 
     /**
      * Set the loop start and stop at the same time.
@@ -1642,9 +1642,7 @@ declare namespace Tone {
    * schedule callbacks using the AudioContext time and
    * uses requestAnimationFrame
    */
-  class Draw extends Tone {
-    constructor();
-
+  interface Draw extends Tone {
     /**
      * The amount of time before the scheduled time that the
      * callback can be invoked. Default is half the time of an
@@ -1668,6 +1666,8 @@ declare namespace Tone {
      */
     schedule(callback: Callback, time: Encoding.Time): this;
   }
+
+  const Draw: Draw;
 
   //------------------
   // Component Classes

--- a/index.d.ts
+++ b/index.d.ts
@@ -2144,8 +2144,8 @@ declare namespace Tone {
 
 
   interface VolumeOptions {
-    volume: Encoding.Decibels;
-    mute: boolean;
+    volume?: Encoding.Decibels;
+    mute?: boolean;
   }
 
   /**


### PR DESCRIPTION
A few various fixes to the typings that I've found while working with them in my project.

Fixes include:

- Makes `startTime` and `duration` parameters on `Transport.scheduleRepeat` optional
- Types `Tone.Draw` as a singleton rather than an instantiable class
- Makes constructor options on `Tone.Volume` optional
- Adds missing typings for `Tone.PingPongDelay` constructor