### PR TITLE
add `loop: boolean` to GrainPlayer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5329,6 +5329,11 @@ declare namespace Tone {
     grainSize: Encoding.Time;
 
     /**
+     * If the buffer should loop once it’s over
+     */
+    loop: boolean;
+
+    /**
      * If loop is true, the loop will end at this position
      */
     loopEnd: Encoding.Time;


### PR DESCRIPTION
This adds the `loop` boolean to GrainPlayer which [is actually supported ](https://github.com/Tonejs/Tone.js/blob/dev/Tone/source/GrainPlayer.js#L79)