### PR TITLE
Fixes typo in method name

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5384,7 +5384,7 @@ declare namespace Tone {
      * Returns a promise which resolves with the list
      * of audio input devices available
      */
-    static enumerateDevise(): Promise<ReadonlyArray<MediaDeviceInfo>>
+    static enumerateDevices(): Promise<ReadonlyArray<MediaDeviceInfo>>
 
     /**
      * Returns an identifier for the represented device that


### PR DESCRIPTION
`enumerateDevise` => `enumerateDevices`